### PR TITLE
注文執行とリスク管理

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,5 +5,20 @@
   "take_profit_atr_multiplier": 10,
   "risk_percentage_per_trade": 1,
   "max_units_per_market": 4,
-  "max_total_risk_percentage": 5
+  "max_total_risk_percentage": 5,
+  "slippage_pips": 0.2,
+  "commission_per_lot": 500,
+  "markets": ["EUR/USD", "USD/JPY"],
+  "take_profit_long_exit_period": 10,
+  "take_profit_short_exit_period": 10,
+  "entry_donchian_period": 20,
+  "account_currency": "JPY",
+  "pip_point_value": {
+    "EUR/USD": 0.0001,
+    "USD/JPY": 0.01
+  },
+  "lot_size": {
+    "EUR/USD": 100000,
+    "USD/JPY": 100000
+  }
 }

--- a/trading_logic.py
+++ b/trading_logic.py
@@ -1,179 +1,892 @@
 import pandas as pd
 import math
+from datetime import datetime
 
-def add_position(positions, new_position, capital):
-    """Adds a new position and updates capital.
+class Order:
+    """
+    Represents a trading order in the system.
+
+    An order can be for entry or exit, market or pending (stop/limit).
+    It holds all information related to a specific trade instruction.
+    """
+    def __init__(self, order_id: str, symbol: str, order_type: str, trade_action: str,
+                 quantity: float, order_price: float = None, status: str = "pending",
+                 fill_price: float = None, commission: float = 0.0, slippage: float = 0.0):
+        """
+        Initializes an Order object.
+
+        Args:
+            order_id (str): Unique identifier for the order.
+            symbol (str): The financial instrument symbol (e.g., "EUR/USD").
+            order_type (str): Type of order, e.g., "market", "stop", "limit".
+            trade_action (str): Action of the trade, either "buy" or "sell".
+            quantity (float): The amount of the instrument to trade (always positive).
+            order_price (float, optional): The price at which to execute for pending orders.
+                                           None for market orders. Defaults to None.
+            status (str, optional): Current status of the order, e.g., "pending", "filled",
+                                    "cancelled". Defaults to "pending".
+            fill_price (float, optional): The price at which the order was filled.
+                                          None until filled. Defaults to None.
+            commission (float, optional): Commission incurred for this order. Defaults to 0.0.
+            slippage (float, optional): Monetary value of slippage incurred for this order. Defaults to 0.0.
+        """
+        self.order_id = order_id
+        self.symbol = symbol
+        self.order_type = order_type  # Type of order: "market", "stop", "limit"
+        self.trade_action = trade_action  # Direction: "buy" or "sell"
+        self.quantity = quantity  # Number of units (always positive)
+        self.order_price = order_price  # Specified price for stop or limit orders
+        self.status = status  # Current state: "pending", "filled", "cancelled"
+        self.fill_price = fill_price  # Actual execution price after filling
+        self.timestamp_created = datetime.now()  # Time when the order object was created
+        self.timestamp_filled = None  # Time when the order was successfully filled
+        self.commission = commission  # Commission fee for this order
+        self.slippage = slippage  # Monetary value of slippage for this order
+
+class Position:
+    """
+    Represents an open position in a financial instrument.
+
+    It tracks the quantity, average entry price, stop-loss levels,
+    take-profit levels (if any), and P&L for an open trade.
+    """
+    def __init__(self, symbol: str, quantity: float, average_entry_price: float,
+                 related_entry_order_id: str, initial_stop_loss_price: float = None,
+                 current_stop_loss_price: float = None, take_profit_price: float = None):
+        """
+        Initializes a Position object.
+
+        Args:
+            symbol (str): The financial instrument symbol (e.g., "EUR/USD").
+            quantity (float): The number of units of the instrument.
+                              Positive for a long position, negative for a short position.
+            average_entry_price (float): The average price at which the position was entered.
+            related_entry_order_id (str): The ID of the entry order that initially created this position.
+            initial_stop_loss_price (float, optional): The initial stop-loss price set when the position
+                                                       was opened or last significantly modified. Defaults to None.
+            current_stop_loss_price (float, optional): The current stop-loss price, which might be
+                                                       adjusted (e.g., trailed). Defaults to None.
+            take_profit_price (float, optional): The take-profit price for this position.
+                                                 (Note: Current strategy uses Donchian exits, not fixed TP orders).
+                                                 Defaults to None.
+        """
+        self.symbol = symbol
+        self.quantity = quantity  # Positive for long positions, negative for short positions
+        self.average_entry_price = average_entry_price
+        self.initial_stop_loss_price = initial_stop_loss_price
+        self.current_stop_loss_price = current_stop_loss_price
+        self.take_profit_price = take_profit_price  # May not be used if strategy relies on dynamic exits
+        self.unrealized_pnl = 0.0  # Profit or loss if the position were closed at current market prices
+        self.realized_pnl = 0.0  # Profit or loss accumulated from partially or fully closing this position
+        self.last_update_timestamp = datetime.now()  # Timestamp of the last modification or P&L update
+        self.related_entry_order_id = related_entry_order_id # ID of the order that opened/last significantly modified this position
+        self.active_stop_loss_order_id: str | None = None  # ID of the currently active stop-loss order linked to this position
+
+def execute_order(order: Order, current_market_price: float, slippage_pips: float,
+                  commission_per_lot: float, pip_point_value: float, lot_size: int) -> Order:
+    """
+    Simulates the execution of a given financial order, updating its state.
+
+    This function calculates the fill price based on the order type, current market price,
+    and specified slippage. It also computes the commission for the trade.
+    The input `order` object is modified in place.
 
     Args:
-        positions (dict): Current open positions.
-        new_position (dict): Position to be added.
-        capital (float): Available capital.
+        order (Order): The Order object to be executed. Must be in "pending" status.
+        current_market_price (float): For market orders, this is the current market price used as a base for fill.
+                                      For stop or limit orders, this should be the order's trigger price
+                                      (order.order_price), as slippage is applied relative to that.
+        slippage_pips (float): The amount of slippage in pips (points).
+                               Slippage is applied such that it's detrimental to the trader
+                               (e.g., buy fills at a higher price, sell fills at a lower price).
+        commission_per_lot (float): The commission fee charged per standard lot.
+        pip_point_value (float): The monetary value of one pip/point movement for a single unit
+                                 of the instrument (e.g., for EUR/USD, if 1 pip = 0.0001 change,
+                                 this is the value of that 0.0001 change for 1 unit of EUR).
+        lot_size (int): The number of units in one standard lot for the instrument.
 
     Returns:
-        tuple: Updated positions and capital.
+        Order: The executed (or state-unchanged if not executable) Order object with updated
+               attributes: `status`, `fill_price`, `commission`, `slippage` (monetary),
+               and `timestamp_filled`.
+
+    Raises:
+        ValueError: If the order has an invalid `trade_action`, an unsupported `order_type`,
+                    or if `lot_size` is non-positive.
     """
-    if not all(key in new_position for key in ['symbol', 'quantity', 'price']):
-        raise ValueError("Missing required keys in new_position: 'symbol', 'quantity', 'price'")
+    if order.status != "pending":
+        # If the order is not pending (e.g., already filled or cancelled), no action is taken.
+        return order
 
-    cost = new_position['quantity'] * new_position['price']
+    # Calculate total monetary slippage: slippage per point * number of points for one unit
+    slippage_amount = slippage_pips * pip_point_value
 
-    if capital < cost:
-        raise ValueError("Not enough capital to add position.")
-
-    symbol = new_position['symbol']
-    if symbol in positions:
-        existing_position = positions[symbol]
-        total_quantity = existing_position['quantity'] + new_position['quantity']
-        if total_quantity == 0: # handles case where new_position is effectively closing out the existing one
-            del positions[symbol]
+    # Determine fill price based on order type and trade action
+    if order.order_type == "market":
+        # Market orders fill based on current_market_price, adjusted by slippage.
+        if order.trade_action == "buy":
+            order.fill_price = current_market_price + slippage_amount
+        elif order.trade_action == "sell":
+            order.fill_price = current_market_price - slippage_amount
         else:
-            existing_position['price'] = (existing_position['price'] * existing_position['quantity'] + \
-                                         new_position['price'] * new_position['quantity']) / total_quantity
-            existing_position['quantity'] = total_quantity
+            raise ValueError(f"Invalid trade action for market order: {order.trade_action}")
+    elif order.order_type == "stop":
+        # Stop orders trigger at order_price. Fill price is order_price adjusted by slippage.
+        # The 'current_market_price' argument for a stop order should be its trigger price (order.order_price).
+        if order.trade_action == "sell":  # Stop-loss for a long position, or a sell-stop entry
+            order.fill_price = order.order_price - slippage_amount # Sells at or below stop price
+        elif order.trade_action == "buy":  # Stop-loss for a short position, or a buy-stop entry
+            order.fill_price = order.order_price + slippage_amount # Buys at or above stop price
+        else:
+            raise ValueError(f"Invalid trade action for stop order: {order.trade_action}")
+    # elif order.order_type == "limit":
+    #     # Placeholder for limit order logic (ensure fill is at order_price or better)
+    #     pass
     else:
-        positions[symbol] = new_position.copy() # Use copy to avoid modifying the original new_position dict
+        raise ValueError(f"Unsupported order type: {order.order_type}")
 
-    capital -= cost
-    return positions, capital
+    # Calculate commission
+    if lot_size <= 0:
+        raise ValueError("Lot size must be positive to calculate commission.")
+    order.commission = (order.quantity / lot_size) * commission_per_lot
 
-def close_position(positions, position_to_close, capital):
-    """Closes an existing position and updates capital.
+    # Store the monetary value of slippage applied to this order
+    order.slippage = slippage_amount
+
+    # Update order status and timestamp
+    order.status = "filled"
+    order.timestamp_filled = datetime.now()
+
+    return order
+
+class PortfolioManager:
+    def __init__(self, initial_capital: float, config: dict):
+        self.positions: dict[str, Position] = {}
+        self.orders: list[Order] = []
+        self.capital = initial_capital
+        self.initial_capital = initial_capital
+        self.trade_log: list[dict] = [] # To store details of executed trades
+        self.config = config # Store relevant config like pip_point_value, lot_size, etc.
+
+    def record_order(self, order: Order):
+        """Adds an order to the internal list of orders."""
+        self.orders.append(order)
+
+    def open_position(self, symbol: str, trade_action: str, quantity: float,
+                        entry_price: float, entry_time: datetime,
+                        stop_loss_price: float, order_id: str,
+                        commission: float, slippage_value: float):
+        """
+        Creates or updates a Position object after an order is filled.
+        Assumes new entries are for symbols with no existing open position or
+        are additions to existing ones in the same direction.
+        """
+        if quantity <= 0:
+            raise ValueError("Quantity for opening a position must be positive.")
+
+        position_quantity = quantity if trade_action == "buy" else -quantity
+        cost_or_proceeds = position_quantity * entry_price # This is negative for buys, positive for sells in terms of cash flow for position value
+                                                        # but capital changes are handled by commission and P&L.
+
+        trade_details = {
+            "order_id": order_id,
+            "symbol": symbol,
+            "action": trade_action,
+            "quantity": quantity,
+            "price": entry_price,
+            "timestamp": entry_time,
+            "commission": commission,
+            "slippage": slippage_value,
+            "type": "entry"
+        }
+
+        if symbol not in self.positions:
+            new_position = Position(
+                symbol=symbol,
+                quantity=position_quantity,
+                average_entry_price=entry_price,
+                initial_stop_loss_price=stop_loss_price,
+                current_stop_loss_price=stop_loss_price,
+                related_entry_order_id=order_id
+            )
+            self.positions[symbol] = new_position
+        else:
+            existing_position = self.positions[symbol]
+            if (existing_position.quantity > 0 and trade_action == "sell") or \
+               (existing_position.quantity < 0 and trade_action == "buy"):
+                # This is an opposing trade. For now, we'll raise an error or handle as a close.
+                # Simple approach: This should ideally be handled by a close_position call first.
+                # For now, let's assume this function is called to *increase* a position or open a new one.
+                raise ValueError(f"Opposing trade for existing position {symbol}. Handle closure separately.")
+
+            # Averaging existing position
+            total_value_existing = existing_position.quantity * existing_position.average_entry_price
+            total_value_new = position_quantity * entry_price # position_quantity is signed
+
+            new_total_quantity = existing_position.quantity + position_quantity
+
+            if new_total_quantity == 0: # Effectively closed out
+                 # This case should ideally be handled by close_position or reduce_position
+                del self.positions[symbol]
+                # Realized P&L calculation would be needed here.
+                # For now, open_position is for opening/increasing.
+            else:
+                existing_position.average_entry_price = (total_value_existing + total_value_new) / new_total_quantity
+                existing_position.quantity = new_total_quantity
+                existing_position.last_update_timestamp = entry_time
+                # Potentially update SL, TP if strategy dictates
+                if stop_loss_price: # Update SL if a new one is provided (e.g. for scaling in)
+                    existing_position.initial_stop_loss_price = stop_loss_price
+                    existing_position.current_stop_loss_price = stop_loss_price
+
+        # Capital adjustment:
+        # Commission is a direct reduction in capital.
+        # Slippage is already incorporated into the entry_price from execute_order.
+        # The "cost" of the position itself is reflected in unrealized P&L.
+        self.capital -= commission
+        self.trade_log.append(trade_details)
+
+        # Create and record the stop-loss order
+        if stop_loss_price is not None:
+            sl_order_id = f"{order_id}_sl"
+            sl_trade_action = "sell" if trade_action == "buy" else "buy"
+
+            # The quantity for the SL order should be the absolute quantity of the position opened/increased
+            # For a new position, this is `abs(position_quantity)`.
+            # If adding to an existing position, the SL order should ideally cover the *entire* new position size.
+            # For simplicity, let's assume the SL order created here is for the quantity of *this specific trade*.
+            # A more complex system might manage multiple SL orders or one SL for the aggregate position.
+            # Current `Position` object (`new_position` or `existing_position`) holds the total quantity.
+
+            target_position = self.positions[symbol] # The position just created or updated
+
+            stop_loss_order = Order(
+                order_id=sl_order_id,
+                symbol=symbol,
+                order_type="stop",
+                trade_action=sl_trade_action,
+                quantity=abs(target_position.quantity), # SL covers the full current position
+                order_price=stop_loss_price,
+                status="pending"
+                # timestamp_created is handled by Order.__init__
+            )
+            self.record_order(stop_loss_order)
+            target_position.active_stop_loss_order_id = sl_order_id
+            # print(f"Created SL order: {sl_order_id} for position {target_position.symbol} at {stop_loss_price}")
+
+        # print(f"Opened/Increased position: {trade_details}, Capital: {self.capital}")
+
+
+    def close_position_completely(self, symbol: str, exit_price: float, exit_time: datetime,
+                                  order_id: str, commission: float, slippage_value: float):
+        """Closes the entire position for a symbol and calculates realized P&L."""
+        position = self.get_open_position(symbol)
+        if not position:
+            raise ValueError(f"No open position found for symbol {symbol} to close.")
+
+        quantity_closed = abs(position.quantity)
+        trade_action = "sell" if position.quantity > 0 else "buy" # Action to close
+
+        # Calculate Realized P&L
+        # For long position (quantity > 0), P&L = (exit_price - entry_price) * quantity
+        # For short position (quantity < 0), P&L = (entry_price - exit_price) * abs(quantity)
+        # Or more generally: (exit_price - entry_price) * position.quantity (if exit is sell for long, buy for short)
+        # Let's consider the cash flow perspective for P&L
+        if position.quantity > 0: # Long position
+            realized_pnl = (exit_price - position.average_entry_price) * position.quantity
+        else: # Short position
+            realized_pnl = (position.average_entry_price - exit_price) * abs(position.quantity)
+
+        realized_pnl -= commission # Net P&L after commission
+
+        self.capital += realized_pnl # Add net P&L to capital
+        # The proceeds/cost of the closing trade itself also affect cash if not just using P&L.
+        # Example: Buy 100 shares at $10 (cost $1000). Sell at $12 (proceeds $1200). P&L = $200.
+        # Capital change = $1200 (inflow) - $1000 (outflow reflected in initial P&L) = $200.
+        # Or, initial capital - commission. Then + realized_pnl.
+        # If we think of capital as cash:
+        # Open long: capital decreases by (entry_price * quantity) + commission
+        # Close long: capital increases by (exit_price * quantity) - commission
+        # Net change = (exit_price * quantity) - (entry_price * quantity) - total_commission
+        # This is complex. Let's simplify: capital is adjusted by P&L and commissions.
+        # When opening, capital was reduced by commission.
+        # The value of the position is tracked in unrealized P&L.
+        # When closing, the unrealized P&L becomes realized.
+        # So, capital += realized_pnl (which already includes commission impact on this specific trade)
+
+        position.realized_pnl += realized_pnl # Accumulate on position object too, though it's being deleted.
+
+        trade_details = {
+            "order_id": order_id,
+            "symbol": symbol,
+            "action": trade_action, # The action that closed the position
+            "quantity": quantity_closed,
+            "price": exit_price,
+            "timestamp": exit_time,
+            "commission": commission,
+            "slippage": slippage_value,
+            "realized_pnl": realized_pnl,
+            "type": "exit"
+        }
+        self.trade_log.append(trade_details)
+        del self.positions[symbol]
+        # print(f"Closed position: {trade_details}, Capital: {self.capital}")
+
+
+    def reduce_position(self, symbol: str, quantity_to_close: float, exit_price: float,
+                        exit_time: datetime, order_id: str, commission: float, slippage_value: float):
+        """Reduces an open position by a certain quantity and realizes P&L for that part."""
+        position = self.get_open_position(symbol)
+        if not position:
+            raise ValueError(f"No open position found for symbol {symbol} to reduce.")
+        if quantity_to_close <= 0:
+            raise ValueError("Quantity to close must be positive.")
+        if quantity_to_close > abs(position.quantity):
+            raise ValueError(f"Cannot close {quantity_to_close}, only {abs(position.quantity)} held for {symbol}.")
+
+        if position.quantity == quantity_to_close or position.quantity == -quantity_to_close :
+            return self.close_position_completely(symbol, exit_price, exit_time, order_id, commission, slippage_value)
+
+        trade_action = "sell" if position.quantity > 0 else "buy"  # Action to reduce/close
+
+        # Calculate Realized P&L for the part being closed
+        if position.quantity > 0: # Long position
+            realized_pnl_reduction = (exit_price - position.average_entry_price) * quantity_to_close
+        else: # Short position
+            realized_pnl_reduction = (position.average_entry_price - exit_price) * quantity_to_close
+
+        realized_pnl_reduction -= commission # Net P&L for this reduction
+
+        self.capital += realized_pnl_reduction # Adjust capital by the net P&L of the reduction
+        position.realized_pnl += realized_pnl_reduction # Accumulate realized P&L on the position
+
+        # Update position quantity
+        if position.quantity > 0:
+            position.quantity -= quantity_to_close
+        else:
+            position.quantity += quantity_to_close # quantity_to_close is positive, position.quantity is negative
+
+        position.last_update_timestamp = exit_time
+
+        trade_details = {
+            "order_id": order_id,
+            "symbol": symbol,
+            "action": trade_action,
+            "quantity": quantity_to_close,
+            "price": exit_price,
+            "timestamp": exit_time,
+            "commission": commission,
+            "slippage": slippage_value,
+            "realized_pnl": realized_pnl_reduction,
+            "type": "reduction"
+        }
+        self.trade_log.append(trade_details)
+        # print(f"Reduced position: {trade_details}, Capital: {self.capital}")
+
+
+    def get_open_position(self, symbol: str) -> Position | None:
+        """
+        Retrieves an open position for a given symbol.
+
+        Args:
+            symbol (str): The symbol of the position to retrieve (e.g., "EUR/USD").
+
+        Returns:
+            Position | None: The Position object if an open position exists for the symbol,
+                             otherwise None.
+        """
+        return self.positions.get(symbol)
+
+    def update_unrealized_pnl(self, current_prices: dict[str, float]):
+        """
+        Updates the unrealized P&L for all currently open positions.
+
+        The calculation is based on the difference between the current market price
+        and the position's average entry price.
+
+        Args:
+            current_prices (dict[str, float]): A dictionary mapping symbols to their
+                                               current market prices. If a symbol for an
+                                               open position is not in this dict, its P&L
+                                               may be set to None or a warning printed.
+        """
+        for symbol, position in self.positions.items():
+            if symbol not in current_prices:
+                print(f"Warning: Current market price for {symbol} not available. Cannot update unrealized P&L.")
+                position.unrealized_pnl = None # Indicate P&L is currently unknown or stale
+                continue
+
+            current_price = current_prices[symbol]
+            if position.quantity > 0: # Long position
+                position.unrealized_pnl = (current_price - position.average_entry_price) * position.quantity
+            elif position.quantity < 0: # Short position
+                position.unrealized_pnl = (position.average_entry_price - current_price) * abs(position.quantity)
+            else:
+                # This case should ideally not occur for a position listed in self.positions
+                position.unrealized_pnl = 0.0
+            position.last_update_timestamp = datetime.now() # Or use timestamp from data feed if available
+
+    def get_total_equity(self, current_prices: dict[str, float]) -> float:
+        """
+        Calculates the total current equity of the portfolio.
+
+        Total equity is defined as the current cash capital plus the sum of
+        unrealized P&L from all open positions. This method first calls
+        `update_unrealized_pnl` to ensure P&L figures are current.
+
+        Args:
+            current_prices (dict[str, float]): Current market prices for all symbols
+                                               held in open positions, used to update P&L.
+
+        Returns:
+            float: The total current equity of the portfolio.
+        """
+        self.update_unrealized_pnl(current_prices) # Ensure P&L is up-to-date
+        total_unrealized_pnl = sum(pos.unrealized_pnl for pos in self.positions.values() if pos.unrealized_pnl is not None)
+        return self.capital + total_unrealized_pnl
+
+    def get_current_total_open_risk_percentage(self) -> float:
+        """
+        Calculates the current total open risk as a percentage of portfolio capital.
+
+        This method sums the monetary risk for all open positions that have an active,
+        pending stop-loss order. The risk for each position is defined as the potential
+        loss from its average entry price to its stop-loss price, multiplied by the
+        position quantity and the instrument's pip/point value per unit.
+
+        The total monetary risk is then divided by the current portfolio cash capital.
+
+        Returns:
+            float: The total open risk percentage. Returns `float('inf')` if capital
+                   is zero or negative and there's positive monetary risk. Returns 0.0
+                   if there's no risk or capital is zero/negative with no risk.
+        """
+        total_monetary_risk = 0.0
+
+        for symbol, position in self.positions.items():
+            if position.active_stop_loss_order_id:
+                # Find the associated pending stop-loss order
+                stop_order = next((o for o in self.orders if o.order_id == position.active_stop_loss_order_id and o.status == "pending"), None)
+
+                if stop_order and stop_order.order_price is not None:
+                    # Retrieve pip/point value per unit for the symbol from config
+                    pip_value_for_one_unit = self.config.get('pip_point_value', {}).get(symbol)
+
+                    if pip_value_for_one_unit is None:
+                        print(f"Warning: Missing pip_point_value for {symbol} in config. Cannot calculate risk for this position.")
+                        continue # Skip risk calculation for this position
+
+                    # Calculate potential loss in price points per unit
+                    potential_loss_price_points = abs(position.average_entry_price - stop_order.order_price)
+
+                    # Calculate monetary risk for this specific position
+                    monetary_risk_for_position = potential_loss_price_points * abs(position.quantity) * pip_value_for_one_unit
+                    total_monetary_risk += monetary_risk_for_position
+
+        if self.capital <= 0:
+            return float('inf') if total_monetary_risk > 0 else 0.0
+
+        return total_monetary_risk / self.capital
+
+
+# def add_position(positions, new_position, capital):
+#     """Adds a new position and updates capital.
+#
+#     Args:
+#         positions (dict): Current open positions.
+#         new_position (dict): Position to be added.
+#         capital (float): Available capital.
+#
+#     Returns:
+#         tuple: Updated positions and capital.
+#     """
+#     if not all(key in new_position for key in ['symbol', 'quantity', 'price']):
+#         raise ValueError("Missing required keys in new_position: 'symbol', 'quantity', 'price'")
+#
+#     cost = new_position['quantity'] * new_position['price']
+#
+#     if capital < cost:
+#         raise ValueError("Not enough capital to add position.")
+#
+#     symbol = new_position['symbol']
+#     if symbol in positions:
+#         existing_position = positions[symbol]
+#         total_quantity = existing_position['quantity'] + new_position['quantity']
+#         if total_quantity == 0: # handles case where new_position is effectively closing out the existing one
+#             del positions[symbol]
+#         else:
+#             existing_position['price'] = (existing_position['price'] * existing_position['quantity'] + \
+#                                          new_position['price'] * new_position['quantity']) / total_quantity
+#             existing_position['quantity'] = total_quantity
+#     else:
+#         positions[symbol] = new_position.copy() # Use copy to avoid modifying the original new_position dict
+#
+#     capital -= cost
+#     return positions, capital
+#
+# def close_position(positions, position_to_close, capital):
+#     """Closes an existing position and updates capital.
+#
+#     Args:
+#         positions (dict): Current open positions.
+#         position_to_close (dict): Position to be closed.
+#         capital (float): Available capital.
+#
+#     Returns:
+#         tuple: Updated positions and capital.
+#     """
+#     if not all(key in position_to_close for key in ['symbol', 'quantity', 'price']):
+#         raise ValueError("Missing required keys in position_to_close: 'symbol', 'quantity', 'price'")
+#
+#     symbol = position_to_close['symbol']
+#     quantity_to_close = position_to_close['quantity']
+#     price = position_to_close['price']
+#
+#     if symbol not in positions:
+#         raise ValueError(f"Symbol {symbol} not found in positions.")
+#
+#     existing_position = positions[symbol]
+#
+#     if quantity_to_close <= 0:
+#         raise ValueError("Quantity to close must be positive.")
+#
+#     if quantity_to_close > existing_position['quantity']:
+#         raise ValueError(f"Cannot close {quantity_to_close} shares of {symbol}. "
+#                          f"Only {existing_position['quantity']} shares held.")
+#
+#     value_closed = quantity_to_close * price
+#     capital += value_closed
+#
+#     existing_position['quantity'] -= quantity_to_close
+#
+#     if existing_position['quantity'] == 0:
+#         del positions[symbol]
+#
+#     return positions, capital
+#
+# def calculate_pnl(positions, current_prices):
+#     """Calculates PnL for all open positions.
+#
+#     Args:
+#         positions (dict): Current open positions.
+#         current_prices (dict): Current market prices.
+#
+#     Returns:
+#         float: Total PnL.
+#     """
+#     total_pnl = 0.0
+#     for symbol, position_data in positions.items():
+#         quantity = position_data['quantity']
+#         cost_basis = position_data['price']
+#
+#         if symbol not in current_prices:
+#             raise ValueError(f"Current price for symbol {symbol} not available in current_prices.")
+#
+#         current_market_price = current_prices[symbol]
+#
+#         current_value = quantity * current_market_price
+#         initial_cost = quantity * cost_basis
+#         position_pnl = current_value - initial_cost
+#         total_pnl += position_pnl
+#
+#     return total_pnl
+
+def run_strategy(historical_data_dict: dict[str, pd.DataFrame], initial_capital: float, config: dict) -> dict:
+    """
+    Simulates a trading strategy using historical price data for multiple symbols.
+
+    This function acts as the main backtesting engine. It initializes a portfolio,
+    iterates through time based on the provided historical data, processes trading
+    signals, manages orders and positions, and calculates performance metrics like
+    equity curve and trade logs.
 
     Args:
-        positions (dict): Current open positions.
-        position_to_close (dict): Position to be closed.
-        capital (float): Available capital.
+        historical_data_dict (dict[str, pd.DataFrame]):
+            A dictionary where keys are instrument symbols (e.g., "EUR/USD") and values are
+            pandas DataFrames. Each DataFrame must be indexed by datetime and contain
+            'Open', 'High', 'Low', 'Close' columns. 'Volume' is optional
+            but not used by the current core logic.
+        initial_capital (float):
+            The starting cash capital for the backtest simulation.
+        config (dict):
+            A comprehensive configuration dictionary containing all parameters needed for
+            the strategy, including:
+            - Instrument-specific details (pip/point values, lot sizes, max units).
+            - Risk management parameters (risk per trade, stop-loss multipliers, total risk limits).
+            - Strategy parameters (indicator periods for Donchian channels, ATR, etc.).
+            - Execution parameters (slippage, commission rates).
+            - List of markets to trade (`config['markets']`).
 
     Returns:
-        tuple: Updated positions and capital.
+        dict: A dictionary containing the results of the backtest, with keys:
+            "equity_curve" (list): A list of (timestamp, equity) tuples representing
+                                   the portfolio's total equity over time.
+            "trade_log" (list): A list of dictionaries, where each dictionary details
+                                an executed trade (from PortfolioManager.trade_log).
+            "final_capital" (float): The final cash capital in the portfolio.
+            "portfolio_summary" (dict): Optional dictionary with more summary statistics.
     """
-    if not all(key in position_to_close for key in ['symbol', 'quantity', 'price']):
-        raise ValueError("Missing required keys in position_to_close: 'symbol', 'quantity', 'price'")
+    portfolio_manager = PortfolioManager(initial_capital=initial_capital, config=config)
+    equity_curve = [] # Stores (timestamp, equity) tuples
 
-    symbol = position_to_close['symbol']
-    quantity_to_close = position_to_close['quantity']
-    price = position_to_close['price']
+    # --- 1. Initialization: Prepare Data and Pre-calculate Indicators ---
+    all_timestamps = set()
+    for symbol_data_df_val in historical_data_dict.values(): # Use a different var name
+        if isinstance(symbol_data_df_val, pd.DataFrame) and not symbol_data_df_val.empty:
+            all_timestamps.update(symbol_data_df_val.index)
 
-    if symbol not in positions:
-        raise ValueError(f"Symbol {symbol} not found in positions.")
+    sorted_timestamps = sorted(list(all_timestamps))
 
-    existing_position = positions[symbol]
+    if not sorted_timestamps:
+        return { # Basic results for no data
+            "equity_curve": [], "trade_log": portfolio_manager.trade_log,
+            "final_capital": portfolio_manager.capital,
+            "message": "No historical data provided or data was empty."
+        }
 
-    if quantity_to_close <= 0:
-        raise ValueError("Quantity to close must be positive.")
+    # Pre-calculate technical indicators for each symbol to be used in the strategy
+    atr_period_val = config.get('atr_period', 20) # Default ATR period if not in config
+    entry_donchian_period_val = config['entry_donchian_period']
+    long_exit_donchian_period_val = config['take_profit_long_exit_period']
+    short_exit_donchian_period_val = config['take_profit_short_exit_period']
 
-    if quantity_to_close > existing_position['quantity']:
-        raise ValueError(f"Cannot close {quantity_to_close} shares of {symbol}. "
-                         f"Only {existing_position['quantity']} shares held.")
+    processed_historical_data = {}
+    for symbol, data_df in historical_data_dict.items():
+        if not isinstance(data_df, pd.DataFrame) or data_df.empty:
+            print(f"Warning: Data for symbol {symbol} is not a valid DataFrame or is empty. Skipping indicator calculation for this symbol.")
+            continue
 
-    value_closed = quantity_to_close * price
-    capital += value_closed
+        df = data_df.copy() # Work on a copy to avoid modifying original data
 
-    existing_position['quantity'] -= quantity_to_close
+        # Calculate and add ATR column
+        df[f'atr_{atr_period_val}'] = calculate_atr(df['High'], df['Low'], df['Close'], period=atr_period_val)
 
-    if existing_position['quantity'] == 0:
-        del positions[symbol]
+        # Calculate and add Donchian Channels for entry signals
+        df[f'donchian_upper_entry_{entry_donchian_period_val}'], df[f'donchian_lower_entry_{entry_donchian_period_val}'] = \
+            calculate_donchian_channel(df['High'], df['Low'], period=entry_donchian_period_val)
 
-    return positions, capital
+        # Calculate and add Donchian Channels for long position exits
+        df[f'donchian_upper_long_exit_{long_exit_donchian_period_val}'], df[f'donchian_lower_long_exit_{long_exit_donchian_period_val}'] = \
+            calculate_donchian_channel(df['High'], df['Low'], period=long_exit_donchian_period_val)
 
-def calculate_pnl(positions, current_prices):
-    """Calculates PnL for all open positions.
+        # Calculate and add Donchian Channels for short position exits
+        df[f'donchian_upper_short_exit_{short_exit_donchian_period_val}'], df[f'donchian_lower_short_exit_{short_exit_donchian_period_val}'] = \
+            calculate_donchian_channel(df['High'], df['Low'], period=short_exit_donchian_period_val)
 
-    Args:
-        positions (dict): Current open positions.
-        current_prices (dict): Current market prices.
+        processed_historical_data[symbol] = df
 
-    Returns:
-        float: Total PnL.
-    """
-    total_pnl = 0.0
-    for symbol, position_data in positions.items():
-        quantity = position_data['quantity']
-        cost_basis = position_data['price']
+    # --- 2. Main Backtesting Loop: Iterate through each timestamp ---
+    for timestamp in sorted_timestamps:
+        current_prices = {} # Stores close prices for symbols at the current timestamp
+        for symbol in config.get('markets', []): # Iterate through configured markets
+            if symbol in processed_historical_data:
+                data_for_symbol = processed_historical_data[symbol]
+                if timestamp in data_for_symbol.index:
+                    current_prices[symbol] = data_for_symbol.loc[timestamp, 'Close']
 
-        if symbol not in current_prices:
-            raise ValueError(f"Current price for symbol {symbol} not available in current_prices.")
+        # Update portfolio's unrealized P&L and record equity at each step
+        portfolio_manager.update_unrealized_pnl(current_prices)
+        equity = portfolio_manager.get_total_equity(current_prices)
+        equity_curve.append((timestamp, equity))
 
-        current_market_price = current_prices[symbol]
+        # --- Trading Logic Sections ---
 
-        current_value = quantity * current_market_price
-        initial_cost = quantity * cost_basis
-        position_pnl = current_value - initial_cost
-        total_pnl += position_pnl
+        # Section 2.1: Process pending stop-loss orders
+        pending_stop_orders = [o for o in portfolio_manager.orders if o.order_type == "stop" and o.status == "pending"]
+        for stop_order in pending_stop_orders:
+            symbol = stop_order.symbol
+            if symbol not in processed_historical_data or timestamp not in processed_historical_data[symbol].index:
+                continue # Skip if market data for this timestamp is missing
 
-    return total_pnl
+            market_data_at_timestamp = processed_historical_data[symbol].loc[timestamp]
+            current_high = market_data_at_timestamp['High']
+            current_low = market_data_at_timestamp['Low']
 
-def run_strategy(historical_data, capital, strategy_params):
-    """Simulates trading strategy on historical data.
+            triggered = False # Flag to indicate if stop order is triggered
+            if stop_order.trade_action == "sell" and current_low <= stop_order.order_price: # SL for long
+                triggered = True
+            elif stop_order.trade_action == "buy" and current_high >= stop_order.order_price: # SL for short
+                triggered = True
 
-    Args:
-        historical_data (list): List of historical market data.
-        capital (float): Available capital.
-        strategy_params (dict): Trading strategy parameters.
+            if triggered:
+                # Execute the triggered stop order
+                executed_order = execute_order(
+                    order=stop_order, current_market_price=stop_order.order_price,
+                    slippage_pips=config['slippage_pips'], commission_per_lot=config['commission_per_lot'],
+                    pip_point_value=config['pip_point_value'][symbol], lot_size=config['lot_size'][symbol]
+                )
+                if executed_order.status == "filled":
+                    try:
+                        # Close the position in portfolio manager
+                        portfolio_manager.close_position_completely(
+                            symbol=symbol, exit_price=executed_order.fill_price,
+                            exit_time=executed_order.timestamp_filled or timestamp,
+                            order_id=executed_order.order_id, commission=executed_order.commission,
+                            slippage_value=executed_order.slippage
+                        )
+                        # Future enhancement: Cancel any corresponding take-profit order for this position.
+                    except ValueError as e:
+                        print(f"Error closing position after SL for {symbol} at {timestamp}: {e}")
 
-    Returns:
-        float: PnL from the strategy execution.
-    """
-    positions = {}
-    current_capital = capital
+        # Section 2.2: Process take-profit signals (Donchian Channel exits)
+        for symbol in list(portfolio_manager.positions.keys()): # Iterate on a copy of keys for safe removal
+            position = portfolio_manager.get_open_position(symbol)
+            if not position: continue # Position might have been closed by SL
 
-    # Example: Iterate through historical data (assuming data points have a 'price' field)
-    # This is a placeholder for actual strategy logic.
-    # A real strategy would generate buy/sell signals and call add_position/close_position.
-    for data_point_index, data_point in enumerate(historical_data):
-        # Placeholder: Print current capital at each step
-        # print(f"Step {data_point_index}: Capital = {current_capital}")
+            if symbol not in processed_historical_data or timestamp not in processed_historical_data[symbol].index:
+                continue
 
-        # In a real strategy, you would:
-        # 1. Analyze data_point and strategy_params to decide actions.
-        # 2. Potentially call add_position or close_position.
-        #    Example:
-        #    if should_buy_signal:
-        #        new_pos = {'symbol': 'XYZ', 'quantity': 10, 'price': data_point['price']}
-        #        try:
-        #            positions, current_capital = add_position(positions, new_pos, current_capital)
-        #        except ValueError as e:
-        #            print(f"Error adding position: {e}")
-        #
-        #    elif should_sell_signal and 'XYZ' in positions:
-        #        pos_to_close = {'symbol': 'XYZ', 'quantity': 5, 'price': data_point['price']}
-        #        try:
-        #            positions, current_capital = close_position(positions, pos_to_close, current_capital)
-        #        except ValueError as e:
-        #            print(f"Error closing position: {e}")
-        pass # No actual trading logic for this placeholder
+            market_data_at_timestamp = processed_historical_data[symbol].loc[timestamp]
+            current_close = market_data_at_timestamp['Close']
+            if pd.isna(current_close): continue
 
-    # Calculate final PnL based on remaining positions and last prices
-    # Assuming the last data_point contains the relevant closing prices for PnL calculation
-    if not historical_data:
-        return 0.0 # No data, no PnL
+            try: # Using f-string constructed column names for clarity
+                long_exit_col = f"donchian_lower_long_exit_{config['take_profit_long_exit_period']}"
+                prev_donchian_lower_for_long_exit = processed_historical_data[symbol][long_exit_col].shift(1).loc[timestamp]
+                short_exit_col = f"donchian_upper_short_exit_{config['take_profit_short_exit_period']}"
+                prev_donchian_upper_for_short_exit = processed_historical_data[symbol][short_exit_col].shift(1).loc[timestamp]
+            except KeyError: continue # Missing Donchian data (e.g. start of series)
+            if pd.isna(prev_donchian_lower_for_long_exit) or pd.isna(prev_donchian_upper_for_short_exit):
+                continue # Not enough data for shifted Donchian value
 
-    final_prices = {}
-    # This is a simplification. In reality, you'd need to map symbols in positions
-    # to their prices in the last data_point.
-    # For this placeholder, we'll assume historical_data contains prices for symbols we might hold.
-    # For a robust solution, historical_data entries should be dicts with symbol keys,
-    # or you need a way to get the price for each symbol held in `positions`.
+            take_profit_triggered = False
+            trade_action_on_exit = ""
+            if position.quantity > 0 and current_close < prev_donchian_lower_for_long_exit: # Long exit
+                take_profit_triggered = True; trade_action_on_exit = "sell"
+            elif position.quantity < 0 and current_close > prev_donchian_upper_for_short_exit: # Short exit
+                take_profit_triggered = True; trade_action_on_exit = "buy"
 
-    # If positions is empty, PnL is simply current_capital - initial_capital
-    if not positions:
-        return current_capital - capital # PnL is the change in capital
+            if take_profit_triggered:
+                tp_order_id = f"{timestamp.strftime('%Y%m%d%H%M%S')}_{symbol}_TP"
+                market_exit_order = Order( # Create a market order to exit
+                    order_id=tp_order_id, symbol=symbol, order_type="market",
+                    trade_action=trade_action_on_exit, quantity=abs(position.quantity)
+                )
+                portfolio_manager.record_order(market_exit_order)
+                # Execute the take-profit market order
+                executed_exit_order = execute_order(
+                    order=market_exit_order, current_market_price=current_close,
+                    slippage_pips=config['slippage_pips'], commission_per_lot=config['commission_per_lot'],
+                    pip_point_value=config['pip_point_value'][symbol], lot_size=config['lot_size'][symbol]
+                )
+                if executed_exit_order.status == "filled":
+                    try:
+                        active_sl_order_id_to_cancel = position.active_stop_loss_order_id
+                        # Close position in portfolio manager
+                        portfolio_manager.close_position_completely(
+                            symbol=symbol, exit_price=executed_exit_order.fill_price,
+                            exit_time=executed_exit_order.timestamp_filled or timestamp,
+                            order_id=executed_exit_order.order_id, commission=executed_exit_order.commission,
+                            slippage_value=executed_exit_order.slippage
+                        )
+                        if active_sl_order_id_to_cancel: # Cancel the original SL order for this position
+                            sl_to_cancel = next((o for o in portfolio_manager.orders if o.order_id == active_sl_order_id_to_cancel and o.status=="pending"), None)
+                            if sl_to_cancel: sl_to_cancel.status = "cancelled"; sl_to_cancel.timestamp_filled = None
+                    except ValueError as e:
+                        print(f"Error closing position after TP for {symbol} at {timestamp}: {e}")
 
-    # If there are positions, we need their final market prices to calculate PnL.
-    # This part requires a bit more structure in historical_data or a separate price feed.
-    # For this placeholder, we'll assume the last data point might be a dict of prices
-    # or we'll just calculate PnL based on capital changes if no positions are left.
+        # Section 2.3: Process new entry signals (Donchian Channel breakouts)
+        for symbol in config.get('markets', []):
+            if portfolio_manager.get_open_position(symbol): continue # Skip if already holding a position
 
-    # Simplified: if any positions are held, this PnL calculation would be more complex.
-    # For now, as no actual trades are made that change 'positions',
-    # the PnL is effectively the change from initial capital.
-    # If trades were made, we would use calculate_pnl with the final prices.
+            if symbol not in processed_historical_data or timestamp not in processed_historical_data[symbol].index:
+                continue # Skip if market data for this timestamp is missing
 
-    # Let's assume the goal is to return the total PnL of the strategy,
-    # not just the PnL of open positions at the end.
-    # The PnL is the final capital minus the initial capital.
-    return current_capital - capital
+            symbol_data_df = processed_historical_data[symbol]
+            current_close = symbol_data_df.loc[timestamp, 'Close']
+            if pd.isna(current_close): continue # Skip if close price is NaN
 
+            # Define expected column names for indicators
+            atr_col = f'atr_{atr_period_val}'
+            donchian_upper_entry_col = f'donchian_upper_entry_{entry_donchian_period_val}'
+            donchian_lower_entry_col = f'donchian_lower_entry_{entry_donchian_period_val}'
+
+            # Ensure required indicator data is present
+            if not all(col in symbol_data_df.columns for col in [atr_col, donchian_upper_entry_col, donchian_lower_entry_col]):
+                continue # Skip if indicators are missing
+
+            # Generate entry signals (1 for long, -1 for short, 0 for no signal)
+            signal_series = generate_entry_signals(
+                close=symbol_data_df['Close'],
+                donchian_upper_entry=symbol_data_df[donchian_upper_entry_col],
+                donchian_lower_entry=symbol_data_df[donchian_lower_entry_col],
+                entry_period=entry_donchian_period_val
+            )
+            current_signal = signal_series.loc[timestamp] if timestamp in signal_series.index else 0
+            if pd.isna(current_signal): current_signal = 0
+
+            if current_signal == 1 or current_signal == -1: # If there's an entry signal
+                # Calculate position size based on risk parameters
+                account_equity = portfolio_manager.get_total_equity(current_prices)
+                risk_percentage_per_trade = config['risk_per_trade']
+                current_atr = symbol_data_df.loc[timestamp, atr_col]
+                if pd.isna(current_atr) or current_atr <= 0: continue # ATR must be valid
+
+                # Ensure symbol-specific config items are present
+                if not (symbol in config['pip_point_value'] and \
+                        symbol in config['lot_size'] and \
+                        symbol in config['max_units_per_market']):
+                    print(f"Warning: Missing symbol-specific config (pip_point_value, lot_size, or max_units_per_market) for {symbol}. Skipping entry.")
+                    continue
+
+                pip_val_per_unit = config['pip_point_value'][symbol]
+                lot_sz = config['lot_size'][symbol]
+                pip_val_per_lot = pip_val_per_unit * lot_sz
+                market_max_units = config['max_units_per_market'][symbol]
+                current_total_risk_perc = portfolio_manager.get_current_total_open_risk_percentage()
+
+                calculated_units = calculate_position_size(
+                    account_equity=account_equity, risk_percentage=risk_percentage_per_trade, atr=current_atr,
+                    pip_value_per_lot=pip_val_per_lot, lot_size=lot_sz,
+                    max_units_per_market=market_max_units, current_units_for_market=0, # No existing position for this symbol
+                    total_risk_percentage_limit=config['total_portfolio_risk_limit'],
+                    current_total_open_risk_percentage=current_total_risk_perc
+                )
+
+                if calculated_units > 0:
+                    # Determine trade action and stop-loss price
+                    stop_loss_atr_multiplier = config['stop_loss_atr_multiplier']
+                    trade_action = "buy" if current_signal == 1 else "sell"
+                    stop_loss_price = current_close - (stop_loss_atr_multiplier * current_atr) if trade_action == "buy" \
+                                 else current_close + (stop_loss_atr_multiplier * current_atr)
+
+                    # Create and execute market order for entry
+                    entry_order_id = f"{timestamp.strftime('%Y%m%d%H%M%S')}_{symbol}_ENTRY"
+                    entry_market_order = Order(
+                        order_id=entry_order_id, symbol=symbol, order_type="market",
+                        trade_action=trade_action, quantity=calculated_units
+                    )
+                    portfolio_manager.record_order(entry_market_order)
+                    executed_entry_order = execute_order(
+                        order=entry_market_order, current_market_price=current_close,
+                        slippage_pips=config['slippage_pips'], commission_per_lot=config['commission_per_lot'],
+                        pip_point_value=pip_val_per_unit, lot_size=lot_sz
+                    )
+                    if executed_entry_order.status == "filled":
+                        try:
+                            # Open position in portfolio manager
+                            portfolio_manager.open_position(
+                                symbol=symbol, trade_action=executed_entry_order.trade_action,
+                                quantity=executed_entry_order.quantity, entry_price=executed_entry_order.fill_price,
+                                entry_time=executed_entry_order.timestamp_filled or timestamp,
+                                stop_loss_price=stop_loss_price, order_id=executed_entry_order.order_id,
+                                commission=executed_entry_order.commission, slippage_value=executed_entry_order.slippage
+                            )
+                        except ValueError as e: # Catch errors from open_position (e.g. opposing trade)
+                            print(f"Error opening position for {symbol} at {timestamp}: {e}")
+
+    # --- 3. Return Results of the Backtest ---
+    return {
+        "equity_curve": equity_curve,
+        "trade_log": portfolio_manager.trade_log,
+        "final_capital": portfolio_manager.capital,
+        "portfolio_summary": { # Optional: more details
+            "initial_capital": portfolio_manager.initial_capital,
+            "final_equity": equity_curve[-1][1] if equity_curve else initial_capital,
+            "total_trades": len(portfolio_manager.trade_log),
+            # Add more summary stats as needed
+        }
+    }
 
 def calculate_donchian_channel(high, low, period):
     """Calculates the Donchian Channel.


### PR DESCRIPTION
## 概要
取引戦略のパート3として、注文執行とリスク管理のモジュールを実装しました。これにより、シグナルに基づいた仮想的な注文の処理、ストップロス注文の自動設定、およびポートフォリオ全体のリスク監視が可能になります。

## 実装内容

### 1. 注文執行モジュール (`trading_logic.py`)
- `Order`クラスおよび`Position`クラスを新規作成し、個別の注文情報と保有ポジション情報を管理。
- `execute_order`関数を実装し、スリッページと手数料を考慮した成行注文およびストップ注文の仮想約定処理を実現。
- `PortfolioManager`クラスを導入し、口座資金、保有ポジション、注文履歴、取引ログを一元管理。

### 2. ストップロス管理
- `PortfolioManager`にて新規ポジション開設時に、ATR(20)の2倍を基準としたストップロス注文を自動的に生成し、関連付けるロジックを実装。
- バックテストループ内で、各足の価格変動に基づきストップロス注文のトリガーを監視・実行。

### 3. 統合リスク管理
- `calculate_position_size`関数を拡張し、以下のリスク管理ルールを組み込み:
    - 1トレードあたりのリスク許容額（口座資金に対する割合）。
    - ATRベースのストップロス幅。
    - 市場ごとの最大許容ユニット数。
    - ポートフォリオ全体の最大リスク許容率（口座資金に対する割合）。
- `PortfolioManager`に`get_current_total_open_risk_percentage`メソッドを実装し、有効なストップロス注文から現在の総リスクを算出。
- 新規注文はこれらのリスク制限を超過しないようサイズ調整され、制限を超える場合はブロックされる。

### 4. バックテストループ (`run_strategy`)
- 過去データ（日足/時間足）をバー単位で処理するよう全面的に再構築。
- ドンチャンチャネル（エントリー/エグジット用）およびATRを事前に計算。
- 各バーで以下の処理を実行:
    1. ストップロス注文の確認と執行。
    2. 利食いシグナル（ドンチャンチャネル・エグジット）の確認と執行。
    3. 新規エントリーシグナル（ドンチャンチャネル・ブレイクアウト）の生成。
    4. リスク管理ルールに基づいたポジションサイズの計算。
    5. 新規ポジションの開設と関連ストップロス注文の設定。
- 資産カーブと全取引のログを記録。

### 5. 設定ファイル (`config.json`)
- スリッページ、取引手数料、対象市場リスト（pip価値、ロットサイズ含む）、リスク許容率、各種テクニカル指標の期間設定などを追加。

### 6. 単体テスト (`test_trading_logic.py`)
- `Order`, `Position`, `execute_order`, `PortfolioManager`（基本機能）、`calculate_position_size`（リスクシナリオ）に対するテストを追加。
- `run_strategy`の基本的なエンドツーエンドテストを実装。
- (注記: `PortfolioManager`の一部の複雑なテストは、私の能力の制約により課題が残りました)

### 7. ドキュメンテーション
- `trading_logic.py`内の新規および大幅に変更されたクラス・関数に対して、docstringとインラインコメントを追記。