### PR TITLE
Add Dependabot configuration for npm and pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ This project also includes several key Python scripts:
     *   **For Backend**: Navigate to the `backend` directory and follow instructions in `backend/README.md`.
     *   **For Frontend**: Navigate to the `frontend` directory and follow instructions in `frontend/README.md`.
 
+## Dependency Management
+This project uses Dependabot to automatically keep dependencies up to date. Dependabot will create pull requests to update npm and pip packages as new versions become available.
+
 ## Quick Start: Running the Full Application
 
 To quickly start both the backend and frontend applications for development, use the `start_all.sh` script located in the project root:


### PR DESCRIPTION
This commit adds a Dependabot configuration file to automatically create pull requests for updating npm and pip dependencies.

The following changes were made:
- Created `.github/dependabot.yml` to configure Dependabot for:
  - npm dependencies in `/frontend`
  - pip dependencies in `/backend`
  - pip dependencies in the root directory
- Updated `README.md` to include a "Dependency Management" section explaining the use of Dependabot.