### PR TITLE
 機能追加：バックテスト実行時にデータファイルを動的に選択

### DIFF
--- a/data/sample.csv
+++ b/data/sample.csv
@@ -1,3 +1,3 @@
-Date,Open,High,Low,Close,Volume
+Timestamp,Open,High,Low,Close,Volume
 2023-01-01,100,105,99,102,1000
 2023-01-02,102,103,101,102.5,1200

--- a/frontend/src/components/BacktestSettingsForm.test.js
+++ b/frontend/src/components/BacktestSettingsForm.test.js
@@ -425,25 +425,6 @@ describe('BacktestSettingsForm', () => {
        expect(parsedBody.initial_capital).toBe(1000000); // Example default value check
 
       expect(mockNavigate).toHaveBeenCalledWith('/loading/job-123-payload-test', expect.anything());
-      });
-
-      await waitFor(() => {
-        expect(mockRunFetch).toHaveBeenCalled();
-      });
-
-      expect(mockRunFetch).toHaveBeenCalledWith(
-        'http://localhost:8000/api/backtest/run',
-        expect.objectContaining({
-          method: 'POST',
-          body: expect.stringContaining('"data_file_name":"file1.csv"'),
-        })
-      );
-      // Also check other essential parts of the payload to ensure it's the correct call
-       const parsedBody = JSON.parse(mockRunFetch.mock.calls[0][1].body);
-       expect(parsedBody.data_file_name).toBe('file1.csv');
-       expect(parsedBody.initial_capital).toBe(1000000); // Example default value check
-
-      expect(mockNavigate).toHaveBeenCalledWith('/loading/job-123-payload-test', expect.anything());
     });
   });
 });

--- a/frontend/src/components/BacktestSettingsForm.test.js
+++ b/frontend/src/components/BacktestSettingsForm.test.js
@@ -147,7 +147,8 @@ describe('BacktestSettingsForm', () => {
     // mockRunBacktestFetch is already set for success by default in beforeEach.
 
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitFor(() => expect(mockDataFilesFetch).toHaveBeenCalled()); // Wait for initial data load
+    // Wait for the initial data file fetch and options to populate
+    await waitFor(() => expect(screen.getByRole('option', { name: 'sample.csv' })).toBeInTheDocument());
 
     const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
 
@@ -165,11 +166,14 @@ describe('BacktestSettingsForm', () => {
     await waitFor(() => expect(screen.queryByText('スプレッド must be a valid number.')).not.toBeInTheDocument());
 
     const fileSelect = screen.getByRole('combobox', { name: /select data file/i });
-    // Explicitly await state update from file selection
     await act(async () => {
       fireEvent.change(fileSelect, { target: { value: 'sample.csv' } });
     });
-    await waitFor(() => expect(fileSelect).toHaveValue('sample.csv')); // Confirm selection
+    // Ensure the selection has taken effect and any related validation messages are cleared
+    await waitFor(() => {
+      expect(fileSelect).toHaveValue('sample.csv');
+      expect(screen.queryByText('Please select a data file to use for the backtest.')).not.toBeInTheDocument();
+    });
 
     // Now click execute
     await act(async () => {
@@ -199,13 +203,16 @@ describe('BacktestSettingsForm', () => {
     });
 
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitFor(() => expect(mockDataFilesFetch).toHaveBeenCalled()); // Wait for file options to be available
+    await waitFor(() => expect(screen.getByRole('option', { name: 'sample.csv' })).toBeInTheDocument()); // Wait for file options
 
     const fileSelect = screen.getByRole('combobox', { name: /select data file/i });
     await act(async () => {
       fireEvent.change(fileSelect, { target: { value: 'sample.csv' } });
     });
-    await waitFor(() => expect(fileSelect).toHaveValue('sample.csv')); // Confirm selection
+    await waitFor(() => {
+      expect(fileSelect).toHaveValue('sample.csv');
+      expect(screen.queryByText('Please select a data file to use for the backtest.')).not.toBeInTheDocument();
+    });
 
     const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
     await act(async () => {
@@ -227,13 +234,16 @@ describe('BacktestSettingsForm', () => {
     });
 
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitFor(() => expect(mockDataFilesFetch).toHaveBeenCalled()); // Wait for file options
+    await waitFor(() => expect(screen.getByRole('option', { name: 'sample.csv' })).toBeInTheDocument()); // Wait for file options
 
     const fileSelect = screen.getByRole('combobox', { name: /select data file/i });
     await act(async () => {
       fireEvent.change(fileSelect, { target: { value: 'sample.csv' } });
     });
-    await waitFor(() => expect(fileSelect).toHaveValue('sample.csv')); // Confirm selection
+    await waitFor(() => {
+      expect(fileSelect).toHaveValue('sample.csv');
+      expect(screen.queryByText('Please select a data file to use for the backtest.')).not.toBeInTheDocument();
+    });
 
     const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
     // For this specific test, clicking executeButton does not need to be wrapped in act

--- a/frontend/src/components/BacktestSettingsForm.test.js
+++ b/frontend/src/components/BacktestSettingsForm.test.js
@@ -26,7 +26,7 @@ jest.mock('./DateRangePicker', () => ({ startDate, endDate, onStartDateChange, o
 
 describe('BacktestSettingsForm', () => {
   let originalFetch;
-  let mockDataFilesFetch; // This specific instance might not be directly checked anymore by waitForInitialLoad
+  let mockDataFilesFetch;
   let mockRunBacktestFetch;
   let mockRunBacktestFailureFetch;
   let mockRunBacktestDelayedFetch;
@@ -37,7 +37,6 @@ describe('BacktestSettingsForm', () => {
     jest.spyOn(console, 'log').mockImplementation(() => {});
     originalFetch = global.fetch;
 
-    // Define individual mock functions for clarity and potential specific assertions
     mockDataFilesFetch = jest.fn(() => Promise.resolve({
       ok: true,
       status: 200,
@@ -53,7 +52,7 @@ describe('BacktestSettingsForm', () => {
     mockRunBacktestFetch = jest.fn(() => Promise.resolve({
       ok: true,
       status: 200,
-      json: async () => ({ job_id: 'test-job-id-success' }), // Changed job_id for clarity from default
+      json: async () => ({ job_id: 'test-job-id-success' }),
       text: async () => JSON.stringify({ job_id: 'test-job-id-success' })
     }));
     mockRunBacktestFailureFetch = jest.fn(() => Promise.resolve({
@@ -63,7 +62,6 @@ describe('BacktestSettingsForm', () => {
       resolveRunBacktestPromise = resolve;
     }));
 
-    // Clear mocks before each test
     mockDataFilesFetch.mockClear();
     mockRunBacktestFetch.mockClear();
     mockRunBacktestFailureFetch.mockClear();
@@ -72,9 +70,6 @@ describe('BacktestSettingsForm', () => {
     global.fetch = jest.fn();
     global.fetch.mockImplementation(async (url) => {
       if (url.includes('/api/data/files')) {
-        // Use the specific mock instance if needed for tests that spy on it,
-        // otherwise, the direct Promise construction is also fine.
-        // For simplicity with waitForInitialLoad checking global.fetch.mock.calls, direct return is fine.
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -89,7 +84,7 @@ describe('BacktestSettingsForm', () => {
         });
       }
       if (url.includes('/api/backtest/run')) {
-        return mockRunBacktestFetch(); // Default to the success mock for /api/backtest/run
+        return mockRunBacktestFetch();
       }
       return Promise.resolve({
         ok: false,
@@ -107,12 +102,10 @@ describe('BacktestSettingsForm', () => {
     global.fetch = originalFetch;
   });
 
-  // Helper function for robust initial load wait
   const waitForInitialLoad = async (options = { expectedFile: 'sample.csv' }) => {
     await waitFor(() => {
       const dataFilesCall = global.fetch.mock.calls.find(call => call[0].includes('/api/data/files'));
       expect(dataFilesCall).not.toBeUndefined();
-
       if (options.expectedFile) {
         expect(screen.getByRole('option', { name: options.expectedFile })).toBeInTheDocument();
       }
@@ -120,7 +113,6 @@ describe('BacktestSettingsForm', () => {
     });
   };
 
-  // Helper function for selecting a file and waiting for state update
   const selectFileAndWait = async (fileName) => {
     const fileSelect = screen.getByRole('combobox', { name: /select data file/i });
     await act(async () => {
@@ -138,6 +130,7 @@ describe('BacktestSettingsForm', () => {
   test('renders all form sections and initial values', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
     await waitForInitialLoad();
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
 
     expect(screen.getByText('自動売買システム バックテスト')).toBeInTheDocument();
     expect(screen.getByText('1. データと期間設定')).toBeInTheDocument();
@@ -149,7 +142,8 @@ describe('BacktestSettingsForm', () => {
 
   test('updates state on input change (e.g., initial capital)', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitForInitialLoad(); // Ensure form is ready
+    await waitForInitialLoad();
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
     const initialCapitalInput = screen.getByLabelText(/初期口座資金/i);
     act(() => {
       fireEvent.change(initialCapitalInput, { target: { value: '2000000' } });
@@ -159,7 +153,8 @@ describe('BacktestSettingsForm', () => {
 
   test('displays validation error for invalid numeric input', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitForInitialLoad(); // Ensure form is ready
+    await waitForInitialLoad();
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
     const spreadInput = screen.getByLabelText(/スプレッド/i);
     act(() => {
       fireEvent.change(spreadInput, { target: { value: 'abc' } });
@@ -169,7 +164,8 @@ describe('BacktestSettingsForm', () => {
 
   test('clears validation error when input becomes valid', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitForInitialLoad(); // Ensure form is ready
+    await waitForInitialLoad();
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
     const spreadInput = screen.getByLabelText(/スプレッド/i);
     act(() => {
       fireEvent.change(spreadInput, { target: { value: 'abc' } });
@@ -183,7 +179,8 @@ describe('BacktestSettingsForm', () => {
 
   test('reset button clears inputs and errors', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitForInitialLoad(); // Ensure form is ready
+    await waitForInitialLoad();
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
     const initialCapitalInput = screen.getByLabelText(/初期口座資金/i);
     act(() => {
       fireEvent.change(initialCapitalInput, { target: { value: 'abc' } });
@@ -204,6 +201,7 @@ describe('BacktestSettingsForm', () => {
   test('"Run Backtest" button performs validation, calls fetch, and navigates on success', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
     await waitForInitialLoad();
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
 
     const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
     const spreadInput = screen.getByLabelText(/スプレッド/i);
@@ -217,7 +215,6 @@ describe('BacktestSettingsForm', () => {
     await waitFor(() => expect(screen.queryByText('スプレッド must be a valid number.')).not.toBeInTheDocument());
     await selectFileAndWait('sample.csv');
 
-    // Additional wait/assertion before clicking execute
     await waitFor(() => {
       expect(screen.getByRole('combobox', { name: /select data file/i })).toHaveValue('sample.csv');
     });
@@ -233,7 +230,6 @@ describe('BacktestSettingsForm', () => {
         body: expect.stringContaining('"data_file_name":"sample.csv"')
       })
     );
-    // Check the job_id from the default mockRunBacktestFetch in beforeEach
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/loading/test-job-id-success', expect.anything()));
     expect(executeButton).not.toBeDisabled();
     expect(executeButton).toHaveTextContent('バックテストを実行する');
@@ -255,6 +251,7 @@ describe('BacktestSettingsForm', () => {
     });
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
     await waitForInitialLoad();
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
     await selectFileAndWait('sample.csv');
     const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
     await act(async () => {
@@ -282,6 +279,7 @@ describe('BacktestSettingsForm', () => {
     });
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
     await waitForInitialLoad();
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
     await selectFileAndWait('sample.csv');
     const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
     fireEvent.click(executeButton);
@@ -319,6 +317,7 @@ describe('BacktestSettingsForm', () => {
       });
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
       await waitForInitialLoad({ expectedFile: 'file1.csv' });
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
       expect(screen.getByLabelText('Select Data File:')).toBeInTheDocument();
       const combobox = screen.getByRole('combobox', { name: /select data file/i });
       expect(combobox).toBeInTheDocument();
@@ -338,6 +337,7 @@ describe('BacktestSettingsForm', () => {
         return Promise.resolve({ ok: false, status: 404, text: async () => 'Unhandled URL' });
       });
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
+      // No waitForInitialLoad here as it expects success. Wait for error directly.
       await waitFor(() => {
         expect(screen.getByText(/Failed to fetch data files. Status: 500/i)).toBeInTheDocument();
       });
@@ -355,6 +355,7 @@ describe('BacktestSettingsForm', () => {
       });
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
       await waitForInitialLoad({ expectedFile: 'file1.csv' });
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
       fillRequiredNumericInputs();
       const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
       fireEvent.click(executeButton);
@@ -375,6 +376,7 @@ describe('BacktestSettingsForm', () => {
       });
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
       await waitForInitialLoad({ expectedFile: 'file1.csv' });
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
       fillRequiredNumericInputs();
       const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
       fireEvent.click(executeButton);
@@ -395,10 +397,10 @@ describe('BacktestSettingsForm', () => {
       });
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
       await waitForInitialLoad({ expectedFile: 'file1.csv' });
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
       fillRequiredNumericInputs();
       await selectFileAndWait('file1.csv');
 
-      // Additional wait/assertion before clicking execute
       await waitFor(() => {
         expect(screen.getByRole('combobox', { name: /select data file/i })).toHaveValue('file1.csv');
       });

--- a/frontend/src/components/BacktestSettingsForm.test.js
+++ b/frontend/src/components/BacktestSettingsForm.test.js
@@ -26,7 +26,7 @@ jest.mock('./DateRangePicker', () => ({ startDate, endDate, onStartDateChange, o
 
 describe('BacktestSettingsForm', () => {
   let originalFetch;
-  let mockDataFilesFetch;
+  let mockDataFilesFetch; // This specific instance might not be directly checked anymore by waitForInitialLoad
   let mockRunBacktestFetch;
   let mockRunBacktestFailureFetch;
   let mockRunBacktestDelayedFetch;
@@ -37,24 +37,27 @@ describe('BacktestSettingsForm', () => {
     jest.spyOn(console, 'log').mockImplementation(() => {});
     originalFetch = global.fetch;
 
-    // Setup individual mocks for fetch calls
-    // Ensure all potentially expected files are available for waitForInitialLoad variations
+    // Define individual mock functions for clarity and potential specific assertions
     mockDataFilesFetch = jest.fn(() => Promise.resolve({
       ok: true,
-      json: () => Promise.resolve({
+      status: 200,
+      json: async () => ({
         files: [
           { name: 'sample.csv', size: 100, created_at: '2023-01-01T00:00:00Z' },
           { name: 'file1.csv', size: 100, created_at: '2023-01-01T00:00:00Z' },
           { name: 'file2.csv', size: 200, created_at: '2023-01-02T00:00:00Z' },
         ]
-      })
+      }),
+      text: async () => JSON.stringify({ files: [ /* as above */ ] })
     }));
     mockRunBacktestFetch = jest.fn(() => Promise.resolve({
       ok: true,
-      json: () => Promise.resolve({ job_id: 'test-job-id-success' })
+      status: 200,
+      json: async () => ({ job_id: 'test-job-id-success' }), // Changed job_id for clarity from default
+      text: async () => JSON.stringify({ job_id: 'test-job-id-success' })
     }));
     mockRunBacktestFailureFetch = jest.fn(() => Promise.resolve({
-      ok: false, status: 500, text: () => Promise.resolve('Internal Server Error')
+      ok: false, status: 500, text: async () => 'Internal Server Error', json: async () => ({detail: 'Internal Server Error'})
     }));
     mockRunBacktestDelayedFetch = jest.fn(() => new Promise(resolve => {
       resolveRunBacktestPromise = resolve;
@@ -66,9 +69,12 @@ describe('BacktestSettingsForm', () => {
     mockRunBacktestFailureFetch.mockClear();
     mockRunBacktestDelayedFetch.mockClear();
 
-    global.fetch = jest.fn(); // Initialize global.fetch as a jest.fn
+    global.fetch = jest.fn();
     global.fetch.mockImplementation(async (url) => {
       if (url.includes('/api/data/files')) {
+        // Use the specific mock instance if needed for tests that spy on it,
+        // otherwise, the direct Promise construction is also fine.
+        // For simplicity with waitForInitialLoad checking global.fetch.mock.calls, direct return is fine.
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -79,23 +85,12 @@ describe('BacktestSettingsForm', () => {
               { name: 'file2.csv', size: 200, created_at: '2023-01-02T00:00:00Z' },
             ]
           }),
-          text: async () => JSON.stringify({ files: [
-            { name: 'sample.csv', size: 100, created_at: '2023-01-01T00:00:00Z' },
-            { name: 'file1.csv', size: 100, created_at: '2023-01-01T00:00:00Z' },
-            { name: 'file2.csv', size: 200, created_at: '2023-01-02T00:00:00Z' },
-          ]})
+          text: async () => JSON.stringify({ files: [ /* as above */ ]})
         });
       }
       if (url.includes('/api/backtest/run')) {
-        // This is the default success case for run backtest
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: async () => ({ job_id: 'default-job-id-from-beforeEach' }),
-          text: async () => JSON.stringify({ job_id: 'default-job-id-from-beforeEach' })
-        });
+        return mockRunBacktestFetch(); // Default to the success mock for /api/backtest/run
       }
-      // Fallback for unhandled URLs
       return Promise.resolve({
         ok: false,
         status: 404,
@@ -115,14 +110,12 @@ describe('BacktestSettingsForm', () => {
   // Helper function for robust initial load wait
   const waitForInitialLoad = async (options = { expectedFile: 'sample.csv' }) => {
     await waitFor(() => {
-      // Check if fetch was called for data files, without relying on a specific mock instance
       const dataFilesCall = global.fetch.mock.calls.find(call => call[0].includes('/api/data/files'));
-      expect(dataFilesCall).not.toBeUndefined(); // Ensure a call to the endpoint was made
+      expect(dataFilesCall).not.toBeUndefined();
 
       if (options.expectedFile) {
         expect(screen.getByRole('option', { name: options.expectedFile })).toBeInTheDocument();
       }
-      // Check that no data fetch error message is displayed initially
       expect(screen.queryByText(/Failed to fetch data files/i)).not.toBeInTheDocument();
     });
   };
@@ -135,10 +128,8 @@ describe('BacktestSettingsForm', () => {
     });
     await waitFor(() => {
       expect(fileSelect).toHaveValue(fileName);
-      // Ensure the "Please select a data file" error is cleared if it was present
       expect(screen.queryByText('Please select a data file to use for the backtest.')).not.toBeInTheDocument();
     });
-    // Add a small delay wrapped in act to help flush state updates
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 0));
     });
@@ -146,21 +137,19 @@ describe('BacktestSettingsForm', () => {
 
   test('renders all form sections and initial values', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitForInitialLoad(); // Use helper
+    await waitForInitialLoad();
 
     expect(screen.getByText('自動売買システム バックテスト')).toBeInTheDocument();
     expect(screen.getByText('1. データと期間設定')).toBeInTheDocument();
     expect(screen.getByText('2. シミュレーション条件')).toBeInTheDocument();
     expect(screen.getByText('3. 戦略パラメータ (適応型短期タートルシステム)')).toBeInTheDocument();
-
-    // Check one initial value as an example
     expect(screen.getByLabelText(/初期口座資金/i)).toHaveValue(1000000);
     expect(screen.getByLabelText(/スプレッド/i)).toHaveValue(1.0);
-    // Add more checks for other initial values if necessary
   });
 
-  test('updates state on input change (e.g., initial capital)', () => {
+  test('updates state on input change (e.g., initial capital)', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
+    await waitForInitialLoad(); // Ensure form is ready
     const initialCapitalInput = screen.getByLabelText(/初期口座資金/i);
     act(() => {
       fireEvent.change(initialCapitalInput, { target: { value: '2000000' } });
@@ -168,8 +157,9 @@ describe('BacktestSettingsForm', () => {
     expect(initialCapitalInput).toHaveValue(2000000);
   });
 
-  test('displays validation error for invalid numeric input', () => {
+  test('displays validation error for invalid numeric input', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
+    await waitForInitialLoad(); // Ensure form is ready
     const spreadInput = screen.getByLabelText(/スプレッド/i);
     act(() => {
       fireEvent.change(spreadInput, { target: { value: 'abc' } });
@@ -177,73 +167,64 @@ describe('BacktestSettingsForm', () => {
     expect(screen.getByText('スプレッド must be a valid number.')).toBeInTheDocument();
   });
 
-  test('clears validation error when input becomes valid', () => {
+  test('clears validation error when input becomes valid', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
+    await waitForInitialLoad(); // Ensure form is ready
     const spreadInput = screen.getByLabelText(/スプレッド/i);
     act(() => {
-      fireEvent.change(spreadInput, { target: { value: 'abc' } }); // Invalid
+      fireEvent.change(spreadInput, { target: { value: 'abc' } });
     });
     expect(screen.getByText('スプレッド must be a valid number.')).toBeInTheDocument();
     act(() => {
-      fireEvent.change(spreadInput, { target: { value: '1.5' } }); // Valid
+      fireEvent.change(spreadInput, { target: { value: '1.5' } });
     });
     expect(screen.queryByText('スプレッド must be a valid number.')).not.toBeInTheDocument();
   });
 
-  test('reset button clears inputs and errors', () => {
+  test('reset button clears inputs and errors', async () => {
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
+    await waitForInitialLoad(); // Ensure form is ready
     const initialCapitalInput = screen.getByLabelText(/初期口座資金/i);
     act(() => {
-      fireEvent.change(initialCapitalInput, { target: { value: 'abc' } }); // Cause an error
+      fireEvent.change(initialCapitalInput, { target: { value: 'abc' } });
     });
     expect(screen.getByText('初期口座資金 must be a valid number.')).toBeInTheDocument();
-
     act(() => {
-      fireEvent.change(initialCapitalInput, { target: { value: '1200000' } }); // Change value
+      fireEvent.change(initialCapitalInput, { target: { value: '1200000' } });
     });
     expect(initialCapitalInput).toHaveValue(1200000);
-
     const resetButton = screen.getByRole('button', { name: /パラメータをデフォルト値に戻す/i });
     act(() => {
       fireEvent.click(resetButton);
     });
-
-    expect(initialCapitalInput).toHaveValue(1000000); // Back to default
-    expect(screen.queryByText('初期口座資金 must be a valid number.')).not.toBeInTheDocument(); // Error cleared
+    expect(initialCapitalInput).toHaveValue(1000000);
+    expect(screen.queryByText('初期口座資金 must be a valid number.')).not.toBeInTheDocument();
   });
 
   test('"Run Backtest" button performs validation, calls fetch, and navigates on success', async () => {
-    // The default global.fetch in beforeEach now handles the success case for mockRunBacktestFetch.
-    // No need to override global.fetch here if this test uses that default success.
-    // If a different job_id is needed, mockRunBacktestFetch can be used with mockImplementationOnce.
-    // For example: mockRunBacktestFetch.mockImplementationOnce(async () => ({ ok: true, json: async () => ({ job_id: 'specific-id' }) }));
-    // Then the global.fetch router would pick it up if the test used: if (url.includes('/api/backtest/run')) return mockRunBacktestFetch();
-
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitForInitialLoad(); // Use helper
+    await waitForInitialLoad();
 
     const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
-
-    // Test case 1: Validation fails (e.g. spread)
     const spreadInput = screen.getByLabelText(/スプレッド/i);
-    fireEvent.change(spreadInput, { target: { value: '' } }); // Invalid: empty
+    fireEvent.change(spreadInput, { target: { value: '' } });
     fireEvent.click(executeButton);
-
     expect(screen.getByText('スプレッド must be a valid number.')).toBeInTheDocument();
     expect(mockRunBacktestFetch).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
 
-    // Test case 2: Validation passes, API call succeeds
-    fireEvent.change(spreadInput, { target: { value: '1.5' } }); // Valid
+    fireEvent.change(spreadInput, { target: { value: '1.5' } });
     await waitFor(() => expect(screen.queryByText('スプレッド must be a valid number.')).not.toBeInTheDocument());
+    await selectFileAndWait('sample.csv');
 
-    await selectFileAndWait('sample.csv'); // Use helper
+    // Additional wait/assertion before clicking execute
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /select data file/i })).toHaveValue('sample.csv');
+    });
 
-    // Now click execute
     await act(async () => {
       fireEvent.click(executeButton);
     });
-
     await waitFor(() => expect(mockRunBacktestFetch).toHaveBeenCalledTimes(1));
     expect(mockRunBacktestFetch).toHaveBeenCalledWith(
       'http://localhost:8000/api/backtest/run',
@@ -252,17 +233,15 @@ describe('BacktestSettingsForm', () => {
         body: expect.stringContaining('"data_file_name":"sample.csv"')
       })
     );
-
+    // Check the job_id from the default mockRunBacktestFetch in beforeEach
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/loading/test-job-id-success', expect.anything()));
     expect(executeButton).not.toBeDisabled();
     expect(executeButton).toHaveTextContent('バックテストを実行する');
   });
 
   test('"Run Backtest" button shows error message on API failure', async () => {
-    // Crucially, override global.fetch for this test
-    global.fetch.mockImplementation(async (url) => { // Made async
+    global.fetch.mockImplementation(async (url) => {
       if (url.includes('/api/data/files')) {
-        // Using the direct Promise structure as in beforeEach for consistency
         return Promise.resolve({
           ok: true, status: 200, json: async () => ({
             files: [{ name: 'sample.csv', size: 100, created_at: '2023-01-01T00:00:00Z' }]
@@ -270,21 +249,17 @@ describe('BacktestSettingsForm', () => {
         });
       }
       if (url.includes('/api/backtest/run')) {
-        return mockRunBacktestFailureFetch(); // This is already a jest.fn that returns a Promise
+        return mockRunBacktestFailureFetch();
       }
       return Promise.resolve({ ok: false, status: 404, text: async () => 'Unhandled URL in test-specific mock' });
     });
-
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitForInitialLoad(); // Use helper
-
-    await selectFileAndWait('sample.csv'); // Use helper
-
+    await waitForInitialLoad();
+    await selectFileAndWait('sample.csv');
     const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
     await act(async () => {
       fireEvent.click(executeButton);
     });
-
     await waitFor(() => expect(mockRunBacktestFailureFetch).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.getByText(/バックテストの開始に失敗しました。サーバーエラー: 500 - Internal Server Error/i)).toBeInTheDocument());
     expect(mockNavigate).not.toHaveBeenCalled();
@@ -292,8 +267,7 @@ describe('BacktestSettingsForm', () => {
   });
 
   test('all inputs are disabled during execution', async () => {
-    // Override global.fetch for this test
-    global.fetch.mockImplementation(async (url) => { // Made async
+    global.fetch.mockImplementation(async (url) => {
       if (url.includes('/api/data/files')) {
         return Promise.resolve({
           ok: true, status: 200, json: async () => ({
@@ -302,42 +276,30 @@ describe('BacktestSettingsForm', () => {
         });
       }
       if (url.includes('/api/backtest/run')) {
-        return mockRunBacktestDelayedFetch(); // This is already a jest.fn that returns a Promise
+        return mockRunBacktestDelayedFetch();
       }
       return Promise.resolve({ ok: false, status: 404, text: async () => 'Unhandled URL in test-specific mock' });
     });
-
     render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-    await waitForInitialLoad(); // Use helper
-
-    await selectFileAndWait('sample.csv'); // Use helper
-
+    await waitForInitialLoad();
+    await selectFileAndWait('sample.csv');
     const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
-    // For this specific test, clicking executeButton does not need to be wrapped in act
-    // because we want to check the immediate synchronous state change of isExecuting
-    // and then await the button text change. The subsequent promise resolution *is* wrapped in act.
     fireEvent.click(executeButton);
-
     const executingButton = await screen.findByRole('button', { name: /実行中.../i });
     expect(executingButton).toBeDisabled();
-
     expect(screen.getByLabelText(/初期口座資金/i)).toBeDisabled();
     expect(screen.getByLabelText(/スプレッド/i)).toBeDisabled();
     expect(screen.getByRole('combobox', { name: /select data file/i })).toBeDisabled();
     expect(screen.getByTestId('start-date')).toBeDisabled();
     expect(screen.getByTestId('end-date')).toBeDisabled();
     expect(screen.getByRole('button', { name: /パラメータをデフォルト値に戻す/i })).toBeDisabled();
-
-    // Resolve the delayed fetch
     await act(async () => {
-      resolveRunBacktestPromise({ ok: true, json: () => Promise.resolve({ job_id: 'test-job-id-disabled' }) });
+      resolveRunBacktestPromise({ ok: true, json: async () => ({ job_id: 'test-job-id-disabled' }) });
     });
-
     await waitFor(() => expect(screen.getByRole('button', { name: /バックテストを実行する/i })).not.toBeDisabled());
     expect(mockNavigate).toHaveBeenCalledWith('/loading/test-job-id-disabled', expect.anything());
   });
 
-  // New describe block for Data File Selection Features
   describe('Data File Selection Features', () => {
     const mockFilesData = {
       files: [
@@ -346,108 +308,65 @@ describe('BacktestSettingsForm', () => {
       ],
       total_files: 2,
     };
-
-    const fillRequiredNumericInputs = () => {
-      // Helper to fill numeric inputs to pass their validation
-      // Based on existing setup, default values might be valid.
-      // If not, this function would set them.
-      // For now, assume default values are valid or tests for numeric inputs cover changes.
-      // Example:
-      // fireEvent.change(screen.getByLabelText(/初期口座資金/i), { target: { value: '1000000' } });
-      // fireEvent.change(screen.getByLabelText(/スプレッド/i), { target: { value: '1.0' } });
-      // ... and so on for all required numeric fields.
-      // For this test suite, we assume default values are fine unless a specific test changes one.
-    };
-
+    const fillRequiredNumericInputs = () => {};
 
     test('renders data file dropdown and populates options on successful fetch', async () => {
-      // This test specifically checks different file data, so override /api/data/files
       global.fetch.mockImplementation(async (url) => {
         if (url.includes('/api/data/files')) {
-          return Promise.resolve({
-            ok: true,
-            status: 200,
-            json: async () => mockFilesData // mockFilesData has file1.csv, file2.csv
-          });
-        }
-        // Other URLs can use the default beforeEach mock or a specific one if needed
-        if (url.includes('/api/backtest/run')) {
-            return mockRunBacktestFetch();
+          return Promise.resolve({ ok: true, status: 200, json: async () => mockFilesData });
         }
         return Promise.resolve({ ok: false, status: 404, text: async () => 'Unhandled URL' });
       });
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-
-      await waitFor(() => {
-        expect(screen.getByLabelText('Select Data File:')).toBeInTheDocument();
-      });
-
+      await waitForInitialLoad({ expectedFile: 'file1.csv' });
+      expect(screen.getByLabelText('Select Data File:')).toBeInTheDocument();
       const combobox = screen.getByRole('combobox', { name: /select data file/i });
       expect(combobox).toBeInTheDocument();
-
       expect(await screen.findByRole('option', { name: '-- Select a data file --' })).toBeInTheDocument();
       expect(await screen.findByRole('option', { name: 'file1.csv' })).toBeInTheDocument();
       expect(await screen.findByRole('option', { name: 'file2.csv' })).toBeInTheDocument();
     });
 
     test('shows error message if fetching data files fails', async () => {
-      // Override for /api/data/files to simulate failure
       global.fetch.mockImplementation(async (url) => {
         if (url.includes('/api/data/files')) {
           return Promise.resolve({
-            ok: false,
-            status: 500,
-            text: async () => 'Server error fetching files',
+            ok: false, status: 500, text: async () => 'Server error fetching files',
             json: async () => ({ detail: 'Server error fetching files' })
           });
         }
         return Promise.resolve({ ok: false, status: 404, text: async () => 'Unhandled URL' });
       });
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-
       await waitFor(() => {
         expect(screen.getByText(/Failed to fetch data files. Status: 500/i)).toBeInTheDocument();
       });
     });
 
     test('validation prevents execution if no data file selected', async () => {
-      // This test uses the default fetch mock from beforeEach for /api/data/files (which returns sample.csv, file1.csv, file2.csv).
-      // It also uses the default mock for /api/backtest/run (mockRunBacktestFetch).
-      // No specific override of global.fetch is needed here if defaults are suitable.
-      // However, if we want to ensure it's the default mockRunBacktestFetch (and not some other test's override)
-      // we can be explicit for the /api/backtest/run part.
       global.fetch.mockImplementation(async (url) => {
         if (url.includes('/api/data/files')) {
-          // Default from beforeEach already provides 'file1.csv'
-          return Promise.resolve({ok:true, status:200, json: async () => ({files: [{name:'file1.csv'}]})});
+           return Promise.resolve({ok:true, status:200, json: async () => ({files: mockFilesData.files })});
         }
         if (url.includes('/api/backtest/run')) {
-          return mockRunBacktestFetch(); // Using default success mock from beforeEach
+          return mockRunBacktestFetch();
         }
         return Promise.resolve({ ok: false, status: 404, text: async () => 'Unhandled URL' });
       });
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
-      await waitForInitialLoad({ expectedFile: 'file1.csv' }); // Use helper
-
-      fillRequiredNumericInputs(); // Ensure other fields are valid
-
+      await waitForInitialLoad({ expectedFile: 'file1.csv' });
+      fillRequiredNumericInputs();
       const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
       fireEvent.click(executeButton);
-
       expect(await screen.findByText('Please select a data file to use for the backtest.')).toBeInTheDocument();
-      // Check that fetch for backtest/run was not called.
-      // The default mock in beforeEach is for backtest/run. We need to ensure it wasn't called for *this* interaction.
-      // Check calls to fetch. If any call was to /api/backtest/run, this fails.
-      const backtestRunCall = global.fetch.mock.calls.find(call => call[0].includes('/api/backtest/run'));
+      const backtestRunCall = global.fetch.mock.calls.find(call => call[0].includes('/api/backtest/run') && call[1]?.method === 'POST');
       expect(backtestRunCall).toBeUndefined();
     });
 
     test('selecting a file clears submit error related to file selection', async () => {
-      // Uses default fetch mock from beforeEach for /api/data/files.
-      // Uses default mock for /api/backtest/run (mockRunBacktestFetch).
-      global.fetch.mockImplementation(async (url) => {
+       global.fetch.mockImplementation(async (url) => {
          if (url.includes('/api/data/files')) {
-           return Promise.resolve({ok:true, status:200, json: async () => ({files: [{name:'file1.csv'}]})});
+           return Promise.resolve({ok:true, status:200, json: async () => ({files: mockFilesData.files})});
          }
          if (url.includes('/api/backtest/run')) {
            return mockRunBacktestFetch();
@@ -456,46 +375,41 @@ describe('BacktestSettingsForm', () => {
       });
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
       await waitForInitialLoad({ expectedFile: 'file1.csv' });
-
       fillRequiredNumericInputs();
       const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
-      fireEvent.click(executeButton); // Attempt to submit without selecting a file
-
+      fireEvent.click(executeButton);
       expect(await screen.findByText('Please select a data file to use for the backtest.')).toBeInTheDocument();
-
-      await selectFileAndWait('file1.csv'); // Use helper, this also asserts error is cleared
+      await selectFileAndWait('file1.csv');
     });
 
     test('includes data_file_name in payload on execute when a file is selected', async () => {
-      const mockSpecificRunFetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ job_id: 'job-123-payload-test' }) }));
-      // Override fetch for this test to use mockSpecificRunFetch for the backtest run
-      global.fetch.mockImplementation(async (url) => { // Made async
+      const mockSpecificRunFetch = jest.fn(() => Promise.resolve({ ok: true, json: async () => ({ job_id: 'job-123-payload-test' }) }));
+      global.fetch.mockImplementation(async (url) => {
         if (url.includes('/api/data/files')) {
-          // Default from beforeEach already provides 'file1.csv'
-           return Promise.resolve({ok:true, status:200, json: async () => ({files: [{name:'file1.csv'}]})});
+           return Promise.resolve({ok:true, status:200, json: async () => ({files: mockFilesData.files})});
         }
         if (url.includes('/api/backtest/run')) {
-          return mockSpecificRunFetch(); // This is already a jest.fn that returns a Promise
+          return mockSpecificRunFetch();
         }
         return Promise.resolve({ ok: false, status: 404, text: async () => 'Unhandled URL in test-specific mock' });
       });
-
       render(<MemoryRouter><BacktestSettingsForm /></MemoryRouter>);
       await waitForInitialLoad({ expectedFile: 'file1.csv' });
+      fillRequiredNumericInputs();
+      await selectFileAndWait('file1.csv');
 
-      fillRequiredNumericInputs(); // Ensure other inputs are valid
-
-      await selectFileAndWait('file1.csv'); // Use helper
+      // Additional wait/assertion before clicking execute
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: /select data file/i })).toHaveValue('file1.csv');
+      });
 
       const executeButton = screen.getByRole('button', { name: /バックテストを実行する/i });
       await act(async () => {
         fireEvent.click(executeButton);
       });
-
       await waitFor(() => {
         expect(mockSpecificRunFetch).toHaveBeenCalled();
       });
-
       expect(mockSpecificRunFetch).toHaveBeenCalledWith(
         'http://localhost:8000/api/backtest/run',
         expect.objectContaining({
@@ -503,11 +417,9 @@ describe('BacktestSettingsForm', () => {
           body: expect.stringContaining('"data_file_name":"file1.csv"'),
         })
       );
-      // Also check other essential parts of the payload to ensure it's the correct call
        const parsedBody = JSON.parse(mockSpecificRunFetch.mock.calls[0][1].body);
        expect(parsedBody.data_file_name).toBe('file1.csv');
-       expect(parsedBody.initial_capital).toBe(1000000); // Example default value check
-
+       expect(parsedBody.initial_capital).toBe(1000000);
       expect(mockNavigate).toHaveBeenCalledWith('/loading/job-123-payload-test', expect.anything());
     });
   });


### PR DESCRIPTION
## 変更の概要

このプルリクエストは、バックテスト実行時のデータファイル選択機能を改善するものです。これまでは固定のファイル名（`historical_data.csv`）が使用されていましたが、あなたが過去に収集したCSVファイルを指定してバックテストを実行できるようになりました。

## 主な変更点

### フロントエンド (`frontend/src/components/BacktestSettingsForm.js`)
- バックテスト設定画面で、利用可能なCSVファイルの一覧をバックエンドAPI (`/api/data/files`) から取得して表示するようにしました。
- 従来のファイルアップロード機能の代わりに、取得したファイル名を選択するドロップダウンメニューを設置しました。
- バックテスト実行時、選択されたファイル名がバックエンドに送信されるようになりました。
- 上記変更に伴い、関連するユニットテストを追加・更新しました。

### バックエンド (`backend/main.py`)
- バックテスト設定のPydanticモデル (`BacktestSettings`) に、データファイル名を指定するための `data_file_name` フィールドを追加しました。
- バックテスト実行処理が、フロントエンドから受け取った `data_file_name` を使用して、`data/` ディレクトリから指定されたファイルを読み込むように変更しました。（ハードコードされた `historical_data.csv` の使用を廃止）
- 指定されたファイルが見つからない場合や無効な場合の適切なエラーハンドリングを追加しました。
- 上記変更に伴い、データロードロジックのユニットテスト (`test_api.py`) を追加・更新しました。

## 影響範囲
- バックテスト設定画面のUIが変更されます。
- バックテスト実行時のデータソース指定方法が変更されます。

## 確認方法
1. フロントエンドとバックエンドを起動します。
2. データ収集機能（Data Managementページなど）を利用して、複数のCSVデータファイルが `data/` ディレクトリに保存されていることを確認します。
3. バックテスト設定画面を開きます。
4. 「Select Data File:」というラベルのついたドロップダウンメニューが表示され、`data/` ディレクトリ内のCSVファイル名が一覧に表示されることを確認します。
5. ドロップダウンから任意のデータファイルを選択し、その他のバックテスト条件を設定してバックテストを実行します。
6. バックエンドのログで、選択したファイルが読み込まれ、バックテストがそのデータを使用して実行されたことを確認します。
7. 異なるファイルを選択しても同様に動作することを確認します。
8. ファイルを選択せずに実行しようとすると、エラーメッセージが表示されることを確認します。